### PR TITLE
わんコメから YouTube のチャットメッセージを取得するようにした

### DIFF
--- a/aituber_3d/Assets/Scenes/SampleScene 5.unity
+++ b/aituber_3d/Assets/Scenes/SampleScene 5.unity
@@ -2347,7 +2347,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &744483215
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/aituber_3d/Assets/Scenes/SampleScene 5.unity
+++ b/aituber_3d/Assets/Scenes/SampleScene 5.unity
@@ -2347,7 +2347,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &744483215
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4265,9 +4265,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 1174615358}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2fc8b7c7e4b937347ab35e1b08eecbaf, type: 3}
+  m_Script: {fileID: 11500000, guid: cb28c9a69fdea91409768e43bb353166, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  debugText: {fileID: 2087620728}
 --- !u!4 &1174615360
 Transform:
   m_ObjectHideFlags: 0
@@ -6602,8 +6603,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchoredPosition: {x: 0, y: -500}
+  m_SizeDelta: {x: 1920, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2087620728
 MonoBehaviour:
@@ -6625,10 +6626,10 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: New Text
+  m_text: Debug Text
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7f790beb4b2f05c4692528208078a79a, type: 2}
+  m_sharedMaterial: {fileID: -2524200077300313474, guid: 7f790beb4b2f05c4692528208078a79a, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/aituber_3d/Assets/Scripts/Views/YouTubeChatDisplay.cs
+++ b/aituber_3d/Assets/Scripts/Views/YouTubeChatDisplay.cs
@@ -102,7 +102,8 @@ namespace Aituber
             {
                 Debug.LogError("No stop words files found in Resources/Text/");
             }
-            FetchCommentAsync();
+            // YouTube のコメントは GetCommentFromOne でわんコメから直接受け取る
+            // FetchCommentAsync();
         }
 
         async UniTask FetchCommentAsync()
@@ -112,7 +113,8 @@ namespace Aituber
                 if (!stopRequested)
                 {
                     var response = await GetChatData(CHAT_API_URL);
-                    if (response != null) {
+                    if (response != null)
+                    {
                         var count = 0;
                         foreach (var message in response.messages)
                         {
@@ -124,17 +126,17 @@ namespace Aituber
 
                             if (!bannedPhrases.Any(word => messageTextHanAlp.Contains(word)))
                             {
-                                count ++;
-                                commentPanelManager.queueManager.AddTextToQueue(new Question(messageTextHanAlp, message.author_name, message.author_image_url,false));
+                                count++;
+                                commentPanelManager.queueManager.AddTextToQueue(new Question(messageTextHanAlp, message.author_name, message.author_image_url, false));
                             }
                             else
                             {
-                                Debug.LogWarning(string.Format("BANワード検知:{0}",messageTextHanAlp));
+                                Debug.LogWarning(string.Format("BANワード検知:{0}", messageTextHanAlp));
                             }
                         }
                         if (count > 0)
                         {
-                            Debug.Log(string.Format("Enqueued {0} YT comments",count));
+                            Debug.Log(string.Format("Enqueued {0} YT comments", count));
                         }
                     }
                     await UniTask.Delay(TimeSpan.FromSeconds(1));


### PR DESCRIPTION
# 変更の概要
SampleScene 5 にて、YouTube のチャットメッセージの取得経路をローカルサーバーでなくわんコメからにしました。

# 変更の背景
Issue #28 の対応。
今回のAIあんのでは、ローカルの Python Server を立てるのをやめて、Unity 側で直接わんコメからメッセージを取得し、Dify 側に送受信する流れになります。今回、わんコメ側の対応を行いました。

なお、GetCommentFromOne.cs というソースコードで、わんコメから直接コメントを受け付けるコードが既に作られていたので、そのまま利用しました。コメントを受け取ったらデバッグ文を表示して破棄しています。今後 Dify との連携をする際にはこのあたりのデータ処理が必要となります。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](../CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
